### PR TITLE
Add tecnoballz-fixed.opk to repository.nfo

### DIFF
--- a/repository.nfo
+++ b/repository.nfo
@@ -69,6 +69,7 @@ Stringrolled.opk|Stringrolled|v1.0|A cat and a girl try to escape together.
 Super Methane Brothers.opk|Super Methane Brothers||Platform game, beat the levels.
 SuperTux.opk|Super Tux|v0.1.1|Side-scrolling platform with a tux as the hero.
 Syobon Action.opk|Syobon Action|Latest|hard and frustrating platform game.
+tecnoballz-fixed.opk|Tecnoballz|v0.93.1|This is a Breakout or Arkanoid like game with a lot of bonus stages. You can buy weapons and bonus between stages. Sometimes you have to defeat a guardian. This game is written in C++ and uses the SDL library.
 tic_tac_toe.opk|TicTacToe|v1.0|Place three marks in a line. Would you like to play a game?
 TailTale.opk|Tail-Tale|v1.0|Puzzle game of color blocks.
 ultratumba_20200330.opk|Ultratumba|2020|Board game for one or two players. Includes EXP.


### PR DESCRIPTION
The original OPK by dmitry_smagin no longer works on newer OD firmwares since they are missing libmikmod. I repackaged the OPK (with dmitry_smagin's permission) with libmikmod from an older OD rootfs for the GCW0 and a launch script.

The repackaged OPK can be found here: https://github.com/JORGETECH/repackaged-opks/raw/main/tecnoballz-fixed.opk